### PR TITLE
Catching throwable errors in exception route

### DIFF
--- a/library/Respect/Rest/Request.php
+++ b/library/Respect/Rest/Request.php
@@ -212,6 +212,30 @@ class Request
             }
         }
     }
+    
+    /**
+     * Does a catch-like operation on an error based on previously
+     * declared instances from Router::exceptionRoute
+     *
+     * @param Error $e Any error
+     *
+     * @return mixed A route forwarding or a silent null
+     */
+    protected function catchError($e)
+    {
+        foreach ($this->route->sideRoutes as $sideRoute) {
+            $errorClass = get_class($e);
+            if (
+                $errorClass      === $sideRoute->class
+                || $sideRoute->class === 'Error'
+                || $sideRoute->class === '\Error'
+            ) {
+                $sideRoute->exception = $e;
+
+                return $this->forward($sideRoute);
+            }
+        }
+    }
 
     /**
      * Generates and returns the response from the current route
@@ -256,6 +280,14 @@ class Request
 
             //Returns whatever the exception routes returned
             return (string) $exceptionResponse;
+        } catch (\Error $e) {
+            //Tries to catch it using catchExceptions()
+            if (!$errorResponse = $this->catchErrors($e)) {
+                throw $e;
+            }
+
+            //Returns whatever the exception routes returned
+            return (string) $errorResponse;
         }
     }
 


### PR DESCRIPTION
Some errors are not being caught with $router->errorRoute.
This commit adds the possibility to catch exceptions and errors in the $router->exceptionRoute() method.